### PR TITLE
Fixed link to Mullvad's config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This tutorial uses Mullvad VPN to show you how to connect yout Fritz!Box to a Wi
 ## Get your wireguard file for Mullvad:
 For other VPN providers, the configuration steps may be different but the setup in the Fritz!Box remains the same<br>
 
-1. Go to the [WireGuard](https://mullvad.net/de/account/#/wireguard-config) configuration file generator.<br>
+1. Go to the [WireGuard](https://mullvad.net/en/account/wireguard-config) configuration file generator.
 2. Use Linux as Platform.<br>
 3. Select a Location.<br>
 4. Click on Download zip archive and save it to your computer.<br>
@@ -30,12 +30,8 @@ For other VPN providers, the configuration steps may be different but the setup 
 ![image](https://user-images.githubusercontent.com/79027536/236583763-4d1687e1-21b9-433a-8a64-3311d2bad684.png)
 
 ## Info:
-If you see this screen, check again if you have internet and if you are registered at myFritz , and then reload the page. 
+If you see this screen, check again if you have internet and if you are registered at myFritz , and then reload the page.
 ![image](https://user-images.githubusercontent.com/79027536/236584344-a9027a75-f8de-4d4a-994e-9fd7f44419f7.png)
 
 ## Test:
 I have tested this with a Fritz!Box 6850 LTE with firmware 7.51 but it also works with all other Fritz!Boxes that support VPN (WireGuard).
-
-
-
-

--- a/german.md
+++ b/german.md
@@ -4,7 +4,7 @@ Dieses Tutorial zeigt Ihnen anhand von Mullvad VPN, wie Sie ihre Fritz!Box mit e
 ## WireGuard datei Runterladen für Mullvad:
 Bei anderen VPN-Anbietern können die Konfigurationsschritte anders aussehen, aber die Einrichtung in der Fritz!Box bleibt gleich
 
-1. Rufen Sie den [WireGuard](https://mullvad.net/de/account/#/wireguard-config)-Konfigurationsdateigenerator auf.<br>
+1. Rufen Sie den [WireGuard](https://mullvad.net/de/account/wireguard-config)-Konfigurationsdateigenerator auf.
 2. Verwenden Sie Linux als Plattform.<br>
 3. Wählen Sie einen Standort.<br>
 4. Klicken Sie auf Download zip archive und speichern Sie es auf Ihrem Computer.<br>
@@ -26,8 +26,8 @@ Bei anderen VPN-Anbietern können die Konfigurationsschritte anders aussehen, ab
 ![image](https://user-images.githubusercontent.com/79027536/236585074-9e301c4d-70e4-452d-836f-25a8d1ef8094.png)
 ![image](https://user-images.githubusercontent.com/79027536/236586374-39ffffc1-07af-400d-a658-c3aaf6d70aa2.png)
 
-## INFO: 
-Wenn Sie diesen Bildschirm sehen, überprüfen Sie noch einmal, ob Sie Internet haben und bei myFritz registriert sind, und laden Sie die Seite dann neu. 
+## INFO:
+Wenn Sie diesen Bildschirm sehen, überprüfen Sie noch einmal, ob Sie Internet haben und bei myFritz registriert sind, und laden Sie die Seite dann neu.
 ![image](https://user-images.githubusercontent.com/79027536/236620526-502ce7ba-0468-499b-b19f-8de2d2e8803a.png)
 
 
@@ -35,7 +35,3 @@ Wenn Sie diesen Bildschirm sehen, überprüfen Sie noch einmal, ob Sie Internet 
 
 ## Test:
 Ich habe das mit einer Fritz!Box 6850 LTE mit Firmware 7.51 getestet, aber es funktioniert auch mit allen anderen Fritz!Boxen, die VPN (WireGuard) unterstützen.
-
-
-
-


### PR DESCRIPTION
This essentally removes the `#` from the link so that it works again on the actual web interface of Mullvad's.